### PR TITLE
composer update 2019-04-19

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.91.6",
+            "version": "3.92.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "9185a0e00f833ca407ab85451dc523b9dd78fbab"
+                "reference": "c701dae225f5418d2fcffbffcd377a461a4db0d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/9185a0e00f833ca407ab85451dc523b9dd78fbab",
-                "reference": "9185a0e00f833ca407ab85451dc523b9dd78fbab",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/c701dae225f5418d2fcffbffcd377a461a4db0d1",
+                "reference": "c701dae225f5418d2fcffbffcd377a461a4db0d1",
                 "shasum": ""
             },
             "require": {
@@ -86,7 +86,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2019-04-17T18:08:24+00:00"
+            "time": "2019-04-18T18:10:56+00:00"
         },
         {
             "name": "cakephp/utility",


### PR DESCRIPTION
- Updating aws/aws-sdk-php (3.91.6 => 3.92.0): Loading from cache
